### PR TITLE
Add server-side validation to packet handlers and inventory operations

### DIFF
--- a/src/main/java/com/lazrproductions/cuffed/inventory/FriskingMenu.java
+++ b/src/main/java/com/lazrproductions/cuffed/inventory/FriskingMenu.java
@@ -2,6 +2,8 @@ package com.lazrproductions.cuffed.inventory;
 
 import javax.annotation.Nonnull;
 
+import com.lazrproductions.cuffed.api.CuffedAPI;
+import com.lazrproductions.cuffed.cap.base.IRestrainableCapability;
 import com.lazrproductions.cuffed.init.ModMenuTypes;
 
 import net.minecraft.world.Container;
@@ -15,6 +17,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 public class FriskingMenu extends AbstractContainerMenu {
+    private static final double MAX_FRISKING_DISTANCE = 4.0;
+
     private final Container container;
     private final int containerRows;
     private final int otherPlayerId;
@@ -82,6 +86,16 @@ public class FriskingMenu extends AbstractContainerMenu {
             if(level.getEntity(otherPlayerId) instanceof Player other) {
                 if(other.isRemoved())
                     return false;
+
+                IRestrainableCapability cap = CuffedAPI.Capabilities.getRestrainableCapability(other);
+                if (cap == null || !cap.armsRestrained()) {
+                    return false;
+                }
+
+                double distance = player.position().distanceTo(other.position());
+                if (distance > MAX_FRISKING_DISTANCE) {
+                    return false;
+                }
             } else
                 return false;
         }

--- a/src/main/java/com/lazrproductions/cuffed/items/PossessionsBox.java
+++ b/src/main/java/com/lazrproductions/cuffed/items/PossessionsBox.java
@@ -212,7 +212,7 @@ public class PossessionsBox extends Item {
 
          @Override
          public AbstractContainerMenu createMenu(int id, @Nonnull Inventory playerInventory, @Nonnull Player p) {
-            return new FriskingMenu(ModMenuTypes.FRISKING_MENU.get(), id, playerInventory, player.getId(), new FriskingContainer(player, boxStack), 5);
+            return new FriskingMenu(ModMenuTypes.FRISKING_MENU.get(), id, playerInventory, player.getId(), new FriskingContainer(player, boxStack, frisker), 5);
          }
       });
    }

--- a/src/main/java/com/lazrproductions/cuffed/packet/LockpickLockPacket.java
+++ b/src/main/java/com/lazrproductions/cuffed/packet/LockpickLockPacket.java
@@ -1,13 +1,17 @@
 package com.lazrproductions.cuffed.packet;
 
-import java.util.UUID;
 import java.util.function.Supplier;
 
 import com.lazrproductions.cuffed.api.CuffedAPI;
+import com.lazrproductions.cuffed.entity.PadlockEntity;
+import com.lazrproductions.cuffed.init.ModItems;
 import com.lazrproductions.lazrslib.common.network.packet.ParameterizedLazrPacket;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.Entity;
 import net.minecraftforge.network.NetworkEvent;
 
 public class LockpickLockPacket extends ParameterizedLazrPacket {
@@ -72,9 +76,33 @@ public class LockpickLockPacket extends ParameterizedLazrPacket {
     }
 
     static class Serverside {
+        private static final double MAX_LOCKPICK_DISTANCE = 6.0;
+
         public static void handleServerside(Supplier<NetworkEvent.Context> ctx, int speedIncreasePerPick, int progressPerPick, int stopCode, int lockId, String lockpickerUUID) {
-            if(stopCode>-1)
-                CuffedAPI.Lockpicking.finishLockpickingLock(stopCode == 0, lockId, UUID.fromString(lockpickerUUID));
+            if(stopCode > -1) {
+                ServerPlayer sender = ctx.get().getSender();
+                if (sender == null) return;
+
+                if (!sender.getItemInHand(InteractionHand.MAIN_HAND).is(ModItems.LOCKPICK.get())) {
+                    return;
+                }
+
+                Entity entity = sender.level().getEntity(lockId);
+                if (!(entity instanceof PadlockEntity padlock)) {
+                    return;
+                }
+
+                double distance = sender.position().distanceTo(padlock.position());
+                if (distance > MAX_LOCKPICK_DISTANCE) {
+                    return;
+                }
+
+                if (!padlock.isLocked()) {
+                    return;
+                }
+
+                CuffedAPI.Lockpicking.finishLockpickingLock(stopCode == 0, lockId, sender.getUUID());
+            }
         }
     }
 }

--- a/src/main/java/com/lazrproductions/cuffed/restraints/base/AbstractRestraint.java
+++ b/src/main/java/com/lazrproductions/cuffed/restraints/base/AbstractRestraint.java
@@ -297,6 +297,9 @@ public abstract class AbstractRestraint {
     public void receiveUtilityPacketServer(ServerPlayer player, int utiltiyCode, int integerArg, boolean booleanArg, double doubleArg, String stringArg) {
         if(utiltiyCode == 102) {
             if(this instanceof IBreakableRestraint breakable) {
+                if (integerArg != -1) {
+                    return;
+                }
                 breakable.incrementDurability(player, integerArg);
             }
         }


### PR DESCRIPTION
This PR addresses several security vulnerabilities related to insufficient server-side validation in packet handlers and the frisking inventory system. These issues could allow malicious clients to bypass intended game mechanics.

## Changes

### Lockpick Packet Handlers
**Files:** `LockpickBlockPacket.java`, `LockpickLockPacket.java`, `LockpickRestraintPacket.java`

- Added distance validation (players must be within range of target)
- Added item verification (player must hold lockpick in main hand)
- Added target type validation (block/entity must be valid lockpickable type)
- Changed to use authenticated sender UUID instead of client-provided UUID
- Added null checks and proper error handling

### Frisking System
**Files:** `FriskingContainer.java`, `FriskingMenu.java`, `PossessionsBox.java`

- Added server-enforced extraction delay (previously client-side only)
- Added restraint state validation (target must remain restrained)
- Added distance validation between frisker and target
- Fixed `stillValid()` to properly validate session state
- Improved item transfer reliability
- Removed dangerous `clearContent()` implementation (just in case)

### Restraint System
**File:** `AbstractRestraint.java`

- Added input validation for durability modification packets
